### PR TITLE
Add piano sound to exercises

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -6,6 +6,7 @@
   <title>Percepção Musical | Nikolas Yuri</title>
   <link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <script src="https://unpkg.com/soundfont-player@0.12.0/dist/soundfont-player.min.js"></script>
 </head>
 <body>
   <header>
@@ -59,6 +60,8 @@
   <script>
     const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
     const context = new (window.AudioContext || window.webkitAudioContext)();
+    let piano = null;
+    Soundfont.instrument(context, 'acoustic_grand_piano', { soundfont: 'MusyngKite' }).then(p => piano = p);
     let currentChord = null, score = 0, round = 0, startTime, currentLevel = 'facil', activeSources = [];
 
     function noteToFrequency(note) {
@@ -70,17 +73,22 @@
       return noteFreqMap[note];
     }
 
-    function playFrequency(freq) {
+    function playNote(name) {
+      if (piano) {
+        const node = piano.play(name + '4', context.currentTime, { gain: 0.5, duration: 2 });
+        return { stop: (when) => node.stop(when) };
+      }
+      const freq = noteToFrequency(name);
       const osc = context.createOscillator();
       const gain = context.createGain();
       osc.type = 'sine';
       osc.frequency.setValueAtTime(freq, context.currentTime);
-      gain.gain.setValueAtTime(0.1, context.currentTime); // volume reduzido
+      gain.gain.setValueAtTime(0.1, context.currentTime);
       osc.connect(gain);
       gain.connect(context.destination);
       osc.start();
-      osc.stop(context.currentTime + 2); // toca por 2 segundos
-      return { osc, gain };
+      osc.stop(context.currentTime + 2);
+      return { stop: (when) => osc.stop(when), osc, gain };
     }
 
     function playChord() {
@@ -98,17 +106,20 @@
       activeSources = [];
       for (let i of intervals) {
         const noteName = notes[(rootIndex + i) % notes.length];
-        const freq = noteToFrequency(noteName);
-        const src = playFrequency(freq);
+        const src = playNote(noteName);
         activeSources.push(src);
       }
       document.getElementById('repeat-btn').style.display = 'inline-block';
     }
 
     function stopChord() {
-      activeSources.forEach(({ osc, gain }) => {
-        gain.gain.exponentialRampToValueAtTime(0.001, context.currentTime + 0.2);
-        osc.stop(context.currentTime + 0.2);
+      activeSources.forEach(src => {
+        if (src.stop) {
+          src.stop(context.currentTime + 0.2);
+        } else if (src.osc && src.gain) {
+          src.gain.gain.exponentialRampToValueAtTime(0.001, context.currentTime + 0.2);
+          src.osc.stop(context.currentTime + 0.2);
+        }
       });
       activeSources = [];
     }


### PR DESCRIPTION
## Summary
- load soundfont-player library
- play piano samples instead of sine waves for ear-training exercise

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a44988a408331b647a55f794f1498