### PR TITLE
Add icons to major/minor buttons

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -35,8 +35,8 @@
           <button onclick="startGame()" class="button">Iniciar</button>
           <button onclick="playChord()" id="repeat-btn" style="display:none;" class="button">Repetir Acorde</button>
           <div id="choices" style="margin-top: 20px; display: none;">
-            <button onclick="checkAnswer('maior')" class="button">Maior</button>
-            <button onclick="checkAnswer('menor')" class="button">Menor</button>
+            <button onclick="checkAnswer('maior')" class="button"><span class="icon" aria-hidden="true">&#43;</span> Maior</button>
+            <button onclick="checkAnswer('menor')" class="button"><span class="icon" aria-hidden="true">&#8722;</span> Menor</button>
             <button onclick="checkAnswer('diminuto')" id="dimBtn" class="button" style="display: none;">Diminuto</button>
             <button onclick="checkAnswer('aumentado')" id="aumBtn" class="button" style="display: none;">Aumentado</button>
             <button onclick="checkAnswer('7')" id="setimaBtn" class="button" style="display: none;">7ª Menor</button>

--- a/style.css
+++ b/style.css
@@ -99,6 +99,10 @@ main {
   margin: 8px;
 }
 
+.button .icon {
+  margin-right: 6px;
+}
+
 .button:hover,
 .cta-box button:hover,
 #result button:hover {


### PR DESCRIPTION
## Summary
- add plus/minus icons to the Major and Minor answer buttons
- style icons with some spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a49c98e48833194b9e74bfed87ad4